### PR TITLE
Fix MCTS search path initialization bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ def backpropagate(path, value):
 def mcts_search(root, net, num_simulations=800):
     for _ in range(num_simulations):
         node = root
-        path = []
+        path = [node]
 
         # Selection
         while node.children:
@@ -181,11 +181,11 @@ def mcts_search(root, net, num_simulations=800):
                 child_node.prior = policy[idx]
                 node.children[idx] = child_node
             # Use the value estimate from the neural network
-            backpropagate(path + [node], value.item())
+            backpropagate(path, value.item())
         else:
             # Terminal node
             value = winner if winner != 0 else 0
-            backpropagate(path + [node], value)
+            backpropagate(path, value)
     # Choose the move with the most visits
     best_move = max(root.children.items(), key=lambda item: item[1].visits)[0]
     return best_move


### PR DESCRIPTION
## Summary
- ensure MCTS backpropagates through the root node by initializing the path with the root node
- remove duplicate leaf node from backpropagation

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import ConnectFour, mcts_search, ConnectNet, MCTSNode
import torch

net = ConnectNet(num_residual_blocks=1)
net.eval()

game = ConnectFour()
root = MCTSNode(game)
move = mcts_search(root, net, num_simulations=10)
print('move', move)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683f50d6e4c4832b9cbea7c977ac3b4a